### PR TITLE
Require argparse arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,74 @@
 # HfSI Project
 
-# Installation
+## Help
+```bash
+docker compose run hfsi python3 /app/src/comparison.py --help
 ```
+```
+usage: comparison.py [-h] -b BASE_DOCUMENT -s SUPPLEMENTAL [SUPPLEMENTAL ...]
+
+Building Code Additions
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -b BASE_DOCUMENT, --base-document BASE_DOCUMENT
+                        Base building code document, e.g. 2022 CA Plumbing Code
+  -s SUPPLEMENTAL [SUPPLEMENTAL ...], --supplemental SUPPLEMENTAL [SUPPLEMENTAL ...]
+                        Supplemental building code documents, e.g. 2022 SF Plumbing
+```
+## Build
+```bash
 docker compose build
-docker compose run hfsi bash
-cd src
-python3 comparison.py
+```
+```
+[+] Building 3.2s (12/12) FINISHED                                       docker:desktop-linux
+ => [hfsi internal] load build definition from Dockerfile                                0.0s
+ => => transferring dockerfile: 789B                                                     0.0s
+ => [hfsi internal] load metadata for docker.io/library/python:3.9-slim                  0.8s
+ => [hfsi internal] load .dockerignore                                                   0.0s
+ => => transferring context: 2B                                                          0.0s
+ => [hfsi 1/6] FROM docker.io/library/python:3.9-slim@sha256:6250eb7983c08b3cf5a7db9309  0.0s
+ => [hfsi internal] load build context                                                   0.4s
+ => => transferring context: 4.59MB                                                      0.4s
+ => CACHED [hfsi 2/6] WORKDIR /app                                                       0.0s
+ => CACHED [hfsi 3/6] RUN apt-get update &&  apt-get install -y  build-essential  curl   0.0s
+ => CACHED [hfsi 4/6] COPY requirements.txt /app/                                        0.0s
+ => CACHED [hfsi 5/6] RUN pip install --no-cache-dir -r requirements.txt                 0.0s
+ => [hfsi 6/6] COPY . /app/                                                              1.3s
+ => [hfsi] exporting to image                                                            0.6s
+ => => exporting layers                                                                  0.6s
+ => => writing image sha256:e1897cb9d209895740c70ac64cc363fce5d517a06fc2fe74460c05f197b  0.0s
+ => => naming to docker.io/library/hfsi-hfsi                                             0.0s
+ => [hfsi] resolving provenance for metadata file                                        0.0s
+```
+## Run
+Build and run container with base doc and two supplemental docs
+```bash
+docker compose run --build hfsi python3 /app/src/comparison.py \
+  -b /app/src/california_plumbing_code.pdf \
+  -s /app/src/oakland_building_code.pdf /app/src/sf_building_code.pdf
+```
+```
+[+] Building 3.1s (12/12) FINISHED                                       docker:desktop-linux
+ => [hfsi internal] load build definition from Dockerfile                                0.0s
+ => => transferring dockerfile: 789B                                                     0.0s
+ => [hfsi internal] load metadata for docker.io/library/python:3.9-slim                  0.7s
+ => [hfsi internal] load .dockerignore                                                   0.0s
+ => => transferring context: 2B                                                          0.0s
+ => [hfsi 1/6] FROM docker.io/library/python:3.9-slim@sha256:6250eb7983c08b3cf5a7db9309  0.0s
+ => [hfsi internal] load build context                                                   0.4s
+ => => transferring context: 2.25MB                                                      0.4s
+ => CACHED [hfsi 2/6] WORKDIR /app                                                       0.0s
+ => CACHED [hfsi 3/6] RUN apt-get update &&  apt-get install -y  build-essential  curl   0.0s
+ => CACHED [hfsi 4/6] COPY requirements.txt /app/                                        0.0s
+ => CACHED [hfsi 5/6] RUN pip install --no-cache-dir -r requirements.txt                 0.0s
+ => [hfsi 6/6] COPY . /app/                                                              1.3s
+ => [hfsi] exporting to image                                                            0.6s
+ => => exporting layers                                                                  0.6s
+ => => writing image sha256:62625a22e1488ea75ae71c15b3e9867ecc3bd3085b88ccde192fba563cf  0.0s
+ => => naming to docker.io/library/hfsi-hfsi                                             0.0s
+ => [hfsi] resolving provenance for metadata file                                        0.0s
+INFO:__main__:Parsing State building code from /app/src/california_plumbing_code.pdf
+INFO:__main__:Parsing City 0 building code from /app/src/oakland_building_code.pdf
+INFO:__main__:Parsing City 1 building code from /app/src/sf_building_code.pdf
 ```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,4 @@
 # HfSI Project
-
-## Help
-```bash
-docker compose run hfsi python3 /app/src/comparison.py --help
-```
-```
-usage: comparison.py [-h] -b BASE_DOCUMENT -s SUPPLEMENTAL [SUPPLEMENTAL ...]
-
-Building Code Additions
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -b BASE_DOCUMENT, --base-document BASE_DOCUMENT
-                        Base building code document, e.g. 2022 CA Plumbing Code
-  -s SUPPLEMENTAL [SUPPLEMENTAL ...], --supplemental SUPPLEMENTAL [SUPPLEMENTAL ...]
-                        Supplemental building code documents, e.g. 2022 SF Plumbing
-```
 ## Build
 ```bash
 docker compose build
@@ -40,6 +23,22 @@ docker compose build
  => => writing image sha256:e1897cb9d209895740c70ac64cc363fce5d517a06fc2fe74460c05f197b  0.0s
  => => naming to docker.io/library/hfsi-hfsi                                             0.0s
  => [hfsi] resolving provenance for metadata file                                        0.0s
+```
+## Help
+```bash
+docker compose run hfsi python3 /app/src/comparison.py --help
+```
+```
+usage: comparison.py [-h] -b BASE_DOCUMENT -s SUPPLEMENTAL [SUPPLEMENTAL ...]
+
+Building Code Additions
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -b BASE_DOCUMENT, --base-document BASE_DOCUMENT
+                        Base building code document, e.g. 2022 CA Plumbing Code
+  -s SUPPLEMENTAL [SUPPLEMENTAL ...], --supplemental SUPPLEMENTAL [SUPPLEMENTAL ...]
+                        Supplemental building code documents, e.g. 2022 SF Plumbing
 ```
 ## Run
 Build and run container with base doc and two supplemental docs

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ```bash
 docker compose build
 ```
+<details>
+
+<summary>output</summary>
+
 ```
 [+] Building 3.2s (12/12) FINISHED                                       docker:desktop-linux
  => [hfsi internal] load build definition from Dockerfile                                0.0s
@@ -24,10 +28,15 @@ docker compose build
  => => naming to docker.io/library/hfsi-hfsi                                             0.0s
  => [hfsi] resolving provenance for metadata file                                        0.0s
 ```
+</details>
+
 ## Help
 ```bash
 docker compose run hfsi python3 /app/src/comparison.py --help
 ```
+<details>
+<summary>output</summary>
+
 ```
 usage: comparison.py [-h] -b BASE_DOCUMENT -s SUPPLEMENTAL [SUPPLEMENTAL ...]
 
@@ -40,6 +49,9 @@ optional arguments:
   -s SUPPLEMENTAL [SUPPLEMENTAL ...], --supplemental SUPPLEMENTAL [SUPPLEMENTAL ...]
                         Supplemental building code documents, e.g. 2022 SF Plumbing
 ```
+
+</details>
+
 ## Run
 Build and run container with base doc and two supplemental docs
 ```bash
@@ -47,6 +59,10 @@ docker compose run --build hfsi python3 /app/src/comparison.py \
   -b /app/src/california_plumbing_code.pdf \
   -s /app/src/oakland_building_code.pdf /app/src/sf_building_code.pdf
 ```
+
+<details>
+<summary>output</summary>
+
 ```
 [+] Building 3.1s (12/12) FINISHED                                       docker:desktop-linux
  => [hfsi internal] load build definition from Dockerfile                                0.0s
@@ -71,3 +87,5 @@ INFO:__main__:Parsing State building code from /app/src/california_plumbing_code
 INFO:__main__:Parsing City 0 building code from /app/src/oakland_building_code.pdf
 INFO:__main__:Parsing City 1 building code from /app/src/sf_building_code.pdf
 ```
+
+</details>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ docker compose build
 </details>
 
 ## Help
+Show the argparse help menu:
 ```bash
 docker compose run hfsi python3 /app/src/comparison.py --help
 ```

--- a/src/comparison.py
+++ b/src/comparison.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import logging
 import re
@@ -15,6 +16,31 @@ OUTPUT_FILE = "dataset.csv"
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+# Set up argument parser
+argparser = argparse.ArgumentParser(description="Building Code Additions")
+argparser.add_argument(
+    "-b",
+    "--base-document",
+    required=True,
+    type=str,
+    help="Base building code document, e.g. 2022 CA Plumbing Code",
+)
+argparser.add_argument(
+    "-c1",
+    "--code1",
+    required=True,
+    type=str,
+    help="Supplemental building code documents 1, e.g. 2022 SF Plumbing",
+)
+argparser.add_argument(
+    "-c2",
+    "--code2",
+    required=True,
+    type=str,
+    help="Supplemental building code documents 2, e.g. 2022 Oakland Plumbing",
+)
+args = argparser.parse_args()
 
 
 @dataclass
@@ -271,18 +297,18 @@ def main():
 
     try:
         # Parse PDFs
-        california_code = parser.parse_pdf("california_plumbing_code.pdf", "California")
-        sf_code = parser.parse_pdf("sf_building_code.pdf", "San Francisco")
-        oakland_code = parser.parse_pdf("oakland_building_code.pdf", "Oakland")
+        state_building_code = parser.parse_pdf(args.base_document, "State")
+        city1_building_code = parser.parse_pdf(args.code1, "City 1")
+        city2_building_code = parser.parse_pdf(args.code2, "City 2")
 
         with open(OUTPUT_FILE, "w") as f:
             f.write("location, section\n")
-            for section in california_code.sections:
-                f.write("california, {}\n".format(section.number))
-            for section in sf_code.sections:
-                f.write("san francisco, {}\n".format(section.number))
-            for section in oakland_code.sections:
-                f.write("oakland, {}\n".format(section.number))
+            for section in state_building_code.sections:
+                f.write("state, {}\n".format(section.number))
+            for section in city1_building_code.sections:
+                f.write("city 1, {}\n".format(section.number))
+            for section in city2_building_code.sections:
+                f.write("city 2, {}\n".format(section.number))
 
         print(f"finished writing CSV to {OUTPUT_FILE}")
 


### PR DESCRIPTION
This PR will require both of these arguments:
1. `-b`/`--base-document`
1. `-s`/`--supplemental`

See the readme changes for full command examples.